### PR TITLE
Fix force update alert not showing after dismissing SKStoreProductViewController and handle no internet connection scenario

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - SSAppUpdater (1.3.0)
+  - SSAppUpdater (1.4.0)
 
 DEPENDENCIES:
   - SSAppUpdater (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  SSAppUpdater: 82f8d464cef8a82ae4f93e91624f6c09905ac32c
+  SSAppUpdater: 43a72d33ff69e75761beb37f88f22e8e802e594d
 
 PODFILE CHECKSUM: c5a4342b1be2471744d071699a15d194c54245b6
 

--- a/Example/SSAppUpdater/Views/ContentView.swift
+++ b/Example/SSAppUpdater/Views/ContentView.swift
@@ -15,12 +15,12 @@ struct ContentView: View {
         VStack {
             Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
                 .onAppear(perform: {
-                    SSAppUpdater.shared.performCheck { (versionInfo) in
+                    SSAppUpdater.shared.performCheck(isForceUpdate: true) {  versionInfo in
                         print(versionInfo)
                     }
 
                     /// Uncomment below function to display custom alert
-                    // checkForUpdateDisplayCustomAlert()
+                    /// checkForUpdateDisplayCustomAlert()
                 })
         }
         .frame(width: 500, height: 500)
@@ -30,7 +30,7 @@ struct ContentView: View {
 // MARK: - Private view
 extension ContentView {
     private func checkForUpdateDisplayCustomAlert() {
-        SSAppUpdater.shared.performCheck(showDefaultAlert: false) { (versionInfo) in
+        SSAppUpdater.shared.performCheckAndDisplayCustomAlert { (versionInfo) in
             DispatchQueue.main.async {
                 if let appVersion = versionInfo.appVersion,
                     let releaseNote = versionInfo.appReleaseNote {

--- a/Sources/SSAppUpdater/Helper/SSNetworkManager.swift
+++ b/Sources/SSAppUpdater/Helper/SSNetworkManager.swift
@@ -1,0 +1,44 @@
+//
+//  SSNetworkManager.swift
+//  Pods
+//
+//  Created by Rishita Panchal on 30/05/24.
+//
+
+import Combine
+import Network
+
+class SSNetworkManager {
+    // MARK: - Variables
+    private let monitor = NWPathMonitor()
+    @Published private(set) var isConnected: Bool = false
+    private var cancellable: AnyCancellable?
+
+    // MARK: - Initialisers
+    init() {
+        startMonitoring()
+    }
+
+    deinit {
+        monitor.cancel()
+        cancellable?.cancel()
+    }
+}
+
+// MARK: - Functions
+extension SSNetworkManager {
+    /// Starts monitoring the internet connection status.
+    private func startMonitoring() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            self?.isConnected = (path.status == .satisfied)
+        }
+
+        let queue = DispatchQueue(label: "InternetConnectionMonitor")
+        monitor.start(queue: queue)
+
+        cancellable = self.$isConnected.sink { isConnected in
+            print("Internet connectivity changed: \(isConnected)")
+        }
+    }
+}
+

--- a/Sources/SSAppUpdater/PerformVersionCheck/PerformVersionCheck.swift
+++ b/Sources/SSAppUpdater/PerformVersionCheck/PerformVersionCheck.swift
@@ -28,6 +28,7 @@ internal class PerformVersionCheck: NSObject, SKStoreProductViewControllerDelega
 extension PerformVersionCheck {
     struct  PerformVersionCheckConstants {
         static let done = "Done"
+        static let baseAppStoreUrl = "itms-apps://itunes.apple.com/app/id"
     }
 }
 
@@ -193,6 +194,12 @@ extension PerformVersionCheck {
      */
     private func launchAppUpdate(trackId: Int) {
         #if os(iOS)
+        if SSAppUpdater.shared.redirectToAppStore {
+            if let appStoreURL = URL(string: "\(PerformVersionCheckConstants.baseAppStoreUrl)\(trackId)") {
+                UIApplication.shared.open(appStoreURL)
+            }
+            return
+        }
         let storeViewController = SKStoreProductViewController()
         storeViewController.loadProduct(
             withParameters: [
@@ -210,7 +217,7 @@ extension PerformVersionCheck {
             }
         }
         #else
-        if SSAppUpdater.shared.redirectToMacAppStore {
+        if SSAppUpdater.shared.redirectToAppStore {
             AppStoreView(trackId: trackId).goToAppStoreApplication()
         } else {
             guard let mainWindow = NSApplication.shared.windows.first else { return }

--- a/Sources/SSAppUpdater/SSAppUpdater.swift
+++ b/Sources/SSAppUpdater/SSAppUpdater.swift
@@ -30,11 +30,11 @@ public class SSAppUpdater {
 
 // MARK: - Functions
 extension SSAppUpdater {
-    /** Shows the update alert.
+    /**
+     Performs a version check and displays a systems default alert based on the result.
         - Parameters:
          - isForceUpdate: A boolean value indicating whether the user wants to **forceUpdate** or **OptionalUpdate**.
          - updateAlertFrequency: The frequency at which the user wants to perform the app update.
-         - showDefaultAlert: A boolean value indicating whether the user wants to show the default `UIAlertController` or custom UI.
          - redirectToAppStoreInMac: A boolean value indicating whether the app should redirect to the App Store on macOS.
          - completion: A closure to return Version Information (App Version Info).
          - skipVersionAllow: A boolean value indicating whether it will allow for **Skip Version** in Alert Controller.
@@ -42,16 +42,28 @@ extension SSAppUpdater {
     public func performCheck(
         isForceUpdate: Bool = false,
         updateAlertFrequency: SSUpdateFrequency = .always,
-        showDefaultAlert: Bool = true,
         skipVersionAllow: Bool = false,
         redirectToAppStore: Bool = false,
         completion: @escaping (SSVersionInfo) -> Void
     ) {
         self.isForceUpdate = isForceUpdate
+        self.showDefaultAlert = true
         self.updateAlertFrequency = updateAlertFrequency
-        self.showDefaultAlert = showDefaultAlert
         self.skipVersionAllow = skipVersionAllow
         self.redirectToAppStore = redirectToAppStore
+        self.versionCheck = PerformVersionCheck(completion: completion)
+    }
+
+    /**
+     Performs a version check and displays a custom alert based on the result.
+
+     This method initiates a version check process and upon completion, invokes the provided completion handler with the version information. You can use that version information in your custom alert
+
+     - Parameters:
+        - completion: A closure to be called upon completion of the version check process. The closure receives an `SSVersionInfo` object containing the version information.
+    */
+    public func performCheckAndDisplayCustomAlert(completion: @escaping (SSVersionInfo) -> Void) {
+        self.showDefaultAlert = false
         self.versionCheck = PerformVersionCheck(completion: completion)
     }
 }

--- a/Sources/SSAppUpdater/SSAppUpdater.swift
+++ b/Sources/SSAppUpdater/SSAppUpdater.swift
@@ -20,7 +20,7 @@ public class SSAppUpdater {
     
     var isForceUpdate: Bool = false
     
-    var redirectToMacAppStore: Bool = false
+    var redirectToAppStore: Bool = false
 
     var skipVersionAllow: Bool = false
     
@@ -44,14 +44,14 @@ extension SSAppUpdater {
         updateAlertFrequency: SSUpdateFrequency = .always,
         showDefaultAlert: Bool = true,
         skipVersionAllow: Bool = false,
-        redirectToMacAppStore: Bool = false,
+        redirectToAppStore: Bool = false,
         completion: @escaping (SSVersionInfo) -> Void
     ) {
         self.isForceUpdate = isForceUpdate
         self.updateAlertFrequency = updateAlertFrequency
         self.showDefaultAlert = showDefaultAlert
         self.skipVersionAllow = skipVersionAllow
-        self.redirectToMacAppStore = redirectToMacAppStore
+        self.redirectToAppStore = redirectToAppStore
         self.versionCheck = PerformVersionCheck(completion: completion)
     }
 }


### PR DESCRIPTION
**Overview:**

- This PR has included:
  - Fix of update alert not showing after dismissing SKStoreProductViewController in forceUpdate.
  - Add no internet connection alert if device is not connected to internet for macOS and iOS.
